### PR TITLE
Add test coverage for and refactor configuration helpers

### DIFF
--- a/cmd/term-check/main.go
+++ b/cmd/term-check/main.go
@@ -4,7 +4,8 @@ import (
 	"strconv"
 
 	"github.com/ragurney/term-check/internal/bot"
-	"github.com/ragurney/term-check/pkg/lib"
+	"github.com/ragurney/term-check/pkg/config"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -12,12 +13,14 @@ import (
 func main() {
 	zerolog.TimeFieldFormat = ""
 
-	id, err := strconv.Atoi(lib.Env("APP_ID", ""))
+	c := config.New()
+
+	id, err := strconv.Atoi(c.Env("APP_ID", ""))
 	if err != nil {
 		log.Fatal().Err(err)
 	}
-	pk := lib.Env("PRIVATE_KEY_PATH", "")
-	ws := lib.Env("WEBHOOK_SECRET_KEY", "")
+	pk := c.Env("PRIVATE_KEY_PATH", "")
+	ws := c.Env("WEBHOOK_SECRET_KEY", "")
 
 	log.Info().Msg("Starting service...")
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/juju/version v0.0.0-20180108022336-b64dbd566305 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/rs/zerolog v1.10.0
+	github.com/stretchr/testify v1.3.0
 	github.com/waigani/diffparser v0.0.0-20180518143736-8ef6bf958d9e
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/bradleyfalzon/ghinstallation v0.1.2 h1:9fdqVadlvEX/EUts5/aIGvx2ujKnGNIMcuCuUrM6s6Q=
 github.com/bradleyfalzon/ghinstallation v0.1.2/go.mod h1:VQsLlCoNa54/CNXcc2DuCfNZrZxqQcyPeqKUugF/2h8=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -30,8 +32,14 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/zerolog v1.10.0 h1:roFDW4AgYGbHnTOAMZ2K8mHJZ/7bSj7txPfvbABIj88=
 github.com/rs/zerolog v1.10.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/waigani/diffparser v0.0.0-20180518143736-8ef6bf958d9e h1:R6qM6h3b187Xfk30HWs3+BxNGCS1UiKC0/+dtz8W1No=
 github.com/waigani/diffparser v0.0.0-20180518143736-8ef6bf958d9e/go.mod h1:Utd1McdLHltgYo8tcyoZVzjYzp+VG1QNZ/mHZ5xR+V4=
 golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac h1:7d7lG9fHOLdL6jZPtnV4LpI41SbohIJ1Atq7U991dMg=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// LookupEnv to allow mocking of os.LookupEnv
+type LookupEnv func(string) (string, bool)
+
+// FatalLog to allow mocking of log.Fatal()
+type FatalLog func(format string, a ...interface{})
+
+// Config has custom configuration methods
+type Config struct {
+	osEnv LookupEnv
+	fatal FatalLog
+}
+
+// New instantiates the Config object
+func New(options ...Option) *Config {
+	c := Config{
+		osEnv: os.LookupEnv,
+		fatal: log.Fatal().Msgf,
+	}
+	for i := range options {
+		options[i](&c)
+	}
+	return &c
+}
+
+// Env looks env value for passed in key, logging and failing if not set
+func (c *Config) Env(name string, fallback string) string {
+	zerolog.TimeFieldFormat = ""
+
+	v, ok := c.osEnv(name)
+	if !ok {
+		if fallback != "" {
+			return fallback
+		}
+		c.fatal("Environment variable is not set: %s", name)
+	}
+	return v
+}

--- a/pkg/config/config.options.go
+++ b/pkg/config/config.options.go
@@ -1,0 +1,18 @@
+package config
+
+// Option represents an option to config object
+type Option func(*Config)
+
+// WithLookupEnv assigns lookupEnv function to config object
+func WithLookupEnv(l LookupEnv) Option {
+	return func(c *Config) {
+		c.osEnv = l
+	}
+}
+
+// WithFatalLog assigns a fatal logging function to config object
+func WithFatalLog(l FatalLog) Option {
+	return func(c *Config) {
+		c.fatal = l
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type envTestCase struct {
+	name           string
+	key            string
+	backup         string
+	env            map[string]string
+	expectFatal    bool
+	expectedOutput string
+}
+
+func TestEnv(t *testing.T) {
+	cases := []envTestCase{
+		{
+			name:           "EnvSuccessfulLookup",
+			key:            "ABC",
+			backup:         "",
+			env:            map[string]string{"ABC": "123"},
+			expectFatal:    false,
+			expectedOutput: "123",
+		},
+		{
+			name:           "EnvBackupValue",
+			key:            "ABC",
+			backup:         "EFG",
+			env:            make(map[string]string),
+			expectFatal:    false,
+			expectedOutput: "EFG",
+		},
+		{
+			name:           "EnvPanicNotFound",
+			key:            "ABC",
+			backup:         "",
+			env:            make(map[string]string),
+			expectFatal:    true,
+			expectedOutput: "",
+		},
+	}
+
+	for _, tc := range cases {
+		mockLookupEnv := func(s string) (string, bool) {
+			res, ok := tc.env[s]
+			return res, ok
+		}
+
+		mockFatalLog := func(format string, a ...interface{}) {
+			panic(fmt.Sprintf(format, a))
+		}
+
+		c := New(
+			WithLookupEnv(mockLookupEnv),
+			WithFatalLog(mockFatalLog),
+		)
+
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectFatal {
+				expectedMessage := "Environment variable is not set: [ABC]"
+				assert.PanicsWithValue(t, expectedMessage, func() { c.Env(tc.key, tc.backup) }, "log.Fatal was not called")
+			} else {
+				assert.Equal(t, tc.expectedOutput, c.Env(tc.key, tc.backup))
+			}
+		})
+	}
+}

--- a/pkg/lib/lib.go
+++ b/pkg/lib/lib.go
@@ -1,25 +1,5 @@
 package lib
 
-import (
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"os"
-)
-
-// Env looks env value for passed in key, logging and failing if not set
-func Env(name string, fallback string) string {
-	zerolog.TimeFieldFormat = ""
-
-	v, ok := os.LookupEnv(name)
-	if !ok {
-		if fallback != "" {
-			return fallback
-		}
-		log.Fatal().Msgf("Environment variable is not set: %s", name)
-	}
-	return v
-}
-
 // Contains returns a boolean indicating whether a string is present in a passed in set of strings
 func Contains(set map[string]struct{}, item string) bool {
 	_, ok := set[item]


### PR DESCRIPTION
Moves `Env` helper out to separate module and adds test coverage for it.